### PR TITLE
feat: add CI and PDF crawl action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm test
+
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: create sample app
+        run: |
+          mkdir sample
+          cat <<'EOP' > sample/package.json
+          {
+            "name": "sample",
+            "version": "1.0.0",
+            "scripts": {
+              "build": "node build.mjs",
+              "start": "node server.mjs"
+            }
+          }
+          EOP
+          cat <<'EOB' > sample/build.mjs
+          import { mkdir, writeFile } from 'fs/promises';
+          await mkdir('build', { recursive: true });
+          await writeFile('build/index.html', '<a href="/about">About</a>');
+          await writeFile('build/about.html', '<a href="/">Home</a>');
+          EOB
+          cat <<'EOS' > sample/server.mjs
+          import http from 'http';
+          import { readFile } from 'fs/promises';
+          import { join } from 'path';
+          const server = http.createServer(async (req, res) => {
+            const file = join('build', req.url === '/' ? '/index.html' : req.url + '.html');
+            res.end(await readFile(file));
+          });
+          server.listen(3000);
+          EOS
+      - name: run action
+        uses: ./
+        with:
+          workdir: sample
+          build_cmd: 'pnpm run build'
+          start_cmd: 'pnpm run start'
+          port: '3000'
+          keep: '2'
+          pdf_dir: 'public/visual-regression'
+          commit: 'false'
+      - run: test -f sample/public/visual-regression/*.pdf
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,20 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
       - name: create sample app
         run: |
           mkdir sample
           cat <<'EOP' > sample/package.json
           {
             "name": "sample",
-            "version": "1.0.0",
-            "scripts": {
-              "build": "node build.mjs",
-              "start": "node server.mjs"
-            }
+            "version": "1.0.0"
           }
           EOP
           cat <<'EOB' > sample/build.mjs
@@ -50,15 +43,22 @@ jobs:
           });
           server.listen(3000);
           EOS
+          cat <<'EOD' > sample/Dockerfile
+          FROM node:20
+          WORKDIR /app
+          COPY package.json build.mjs server.mjs ./
+          RUN node build.mjs
+          EXPOSE 3000
+          CMD ["node","server.mjs"]
+          EOD
       - name: run action
         uses: ./
         with:
-          workdir: sample
-          build_cmd: 'pnpm run build'
-          start_cmd: 'pnpm run start'
+          context: sample
+          dockerfile: Dockerfile
           port: '3000'
           keep: '2'
-          pdf_dir: 'public/visual-regression'
+          output_dir: 'sample/public/visual-regression'
           commit: 'false'
       - run: test -f sample/public/visual-regression/*.pdf
 

--- a/.github/workflows/visreq.yml
+++ b/.github/workflows/visreq.yml
@@ -12,10 +12,9 @@ jobs:
       - name: 📄 visual regression PDF
         uses: Cdaprod/nextjs-visreg-pdf@v1
         with:
-          workdir: docker/web-app            # ← where your Next.js project lives
-          build_cmd: 'pnpm run build'
-          start_cmd: 'pnpm run start'
+          context: docker/web-app            # ← path containing your Dockerfile
+          dockerfile: Dockerfile
           port: '3000'
           keep: '5'
-          pdf_dir: 'public/visual-regression'
+          output_dir: 'public/visual-regression'
 

--- a/.github/workflows/visreq.yml
+++ b/.github/workflows/visreq.yml
@@ -1,7 +1,7 @@
 name: visreg
 
 on:
-  push: { branches: [ main ] }
+  workflow_dispatch:
 
 jobs:
   pdf:
@@ -18,3 +18,4 @@ jobs:
           port: '3000'
           keep: '5'
           pdf_dir: 'public/visual-regression'
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 #### By: [Cdaprod](https://github.com/Cdaprod)
 
-A simple GitHub Action that builds any Next.js App-Router project, crawls all internal pages, renders them into a single PDF, and commits the newest N PDFs back into your repo for easy public review.
+A GitHub Action that builds your Next.js App‑Router project into a Docker image, runs the resulting container, crawls every internal page, renders them into a single PDF, and commits the newest N PDFs back for easy review.
 
 ## Why this exists
 
 Keeping visual snapshots of your app across commits helps you track UI drift without manual screenshot updates. This Action automates:
-- Building your Next.js app from any subdirectory
+- Building your app's Docker image from any context directory
 - Discovering every internal route up to a configurable depth
 - Rendering each page into a combined PDF
 - Saving that PDF under `docs/visual-regression/<commit>.pdf`
@@ -15,23 +15,22 @@ Keeping visual snapshots of your app across commits helps you track UI drift wit
 
 ### Getting started
 1. In your workflow YAML, add a step that uses `Cdaprod/nextjs-visreg-pdf@v1`.
-2. Provide inputs such as `workdir`, `build_cmd`, `start_cmd`, `port`, `keep` (how many PDFs to keep), `pdf_dir` (where to store them) and optional `commit` to disable pushing.
+2. Provide inputs such as `context` (Docker build context), optional `dockerfile`, `port`, `output_dir`, `keep`, and optional `commit` to disable pushing.
 3. On each push to your main branch, you’ll get an updated PDF in `docs/visual-regression/` and only the latest N versions will linger.
 
 ### Key inputs
-- `workdir`: subfolder where your Next.js project lives (e.g. `docker/web-app`)
-- `build_cmd`: command to build your site (e.g. `pnpm run build`)
-- `start_cmd`: command to launch the production server (e.g. `pnpm run start`)
-- `port`: port that the server listens on (default `3000`)
+- `context`: folder containing your app's Dockerfile (e.g. `docker/web-app`)
+- `dockerfile`: Dockerfile name within that context (default `Dockerfile`)
+- `port`: port exposed by the container (default `3000`)
 - `keep`: number of historical PDFs to preserve (default `5`)
-- `pdf_dir`: path in the repo where PDFs are saved (default `docs/visual-regression`)
+- `output_dir`: path in the repo where PDFs are saved (default `docs/visual-regression`)
 - `commit`: set to `false` to skip committing in CI examples
 
 ### How it works
-1. Install & build: runs your install and build steps in the specified `workdir`.
-2. Start server: boots the production build and waits for the port to open.
-3. Crawl & render: automatically follows links up to the given depth, captures each page into a PDF buffer, then merges them.
-4. Commit & prune: places the new PDF into `pdf_dir` with the current commit SHA, deletes any beyond the newest `keep`, and pushes the change back.
+1. Build image: `docker build` is run against the provided context and Dockerfile.
+2. Run container: the image starts detached and the action waits for the port to open.
+3. Crawl & render: all internal routes are followed up to the given depth and merged into a PDF.
+4. Commit & prune: the PDF is placed into `output_dir` with the current commit SHA, older files beyond `keep` are removed, and the change is optionally pushed.
 
 #### Example usage
 
@@ -40,12 +39,11 @@ _In your `.github/workflows/visreg.yml`, include:_
 ```yaml
 uses: Cdaprod/nextjs-visreg-pdf@v1
 with:
-  workdir: docker/web-app
-  build_cmd: pnpm run build
-  start_cmd: pnpm run start
+  context: docker/web-app
+  dockerfile: Dockerfile
   port: 3000
   keep: 5
-  pdf_dir: public/visual-regression
+  output_dir: public/visual-regression
 ```
 
 That’s it—on each push to main you’ll end up with a shareable PDF of your whole app, and your repo will always contain only the last five visual-regression artifacts.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Next.js Visual Regression to PDF
 
-#### By: [Cdaprod](github.com/Cdaprod)
+#### By: [Cdaprod](https://github.com/Cdaprod)
 
 A simple GitHub Action that builds any Next.js App-Router project, crawls all internal pages, renders them into a single PDF, and commits the newest N PDFs back into your repo for easy public review.
 
@@ -10,31 +10,32 @@ Keeping visual snapshots of your app across commits helps you track UI drift wit
 - Building your Next.js app from any subdirectory
 - Discovering every internal route up to a configurable depth
 - Rendering each page into a combined PDF
-- Saving that PDF under docs/visual-regression/<commit>.pdf
+- Saving that PDF under `docs/visual-regression/<commit>.pdf`
 - Pruning older files so only the last X remain
 
 ### Getting started
-1. In your workflow YAML, add a step that uses Cdaprod/nextjs-visreg-pdf@v1.
-2. Provide inputs such as workdir, build_cmd, start_cmd, port, keep (how many PDFs to keep), and pdf_dir (where to store them).
-3. On each push to your main branch, you’ll get an updated PDF in docs/visual-regression/ and only the latest N versions will linger.
+1. In your workflow YAML, add a step that uses `Cdaprod/nextjs-visreg-pdf@v1`.
+2. Provide inputs such as `workdir`, `build_cmd`, `start_cmd`, `port`, `keep` (how many PDFs to keep), `pdf_dir` (where to store them) and optional `commit` to disable pushing.
+3. On each push to your main branch, you’ll get an updated PDF in `docs/visual-regression/` and only the latest N versions will linger.
 
 ### Key inputs
-- workdir: subfolder where your Next.js project lives (e.g. docker/web-app)
-- build_cmd: command to build your site (e.g. pnpm run build)
-- start_cmd: command to launch the production server (e.g. pnpm run start)
-- port: port that the server listens on (default 3000)
-- keep: number of historical PDFs to preserve (default 5)
-- pdf_dir: path in the repo where PDFs are saved (default docs/visual-regression)
+- `workdir`: subfolder where your Next.js project lives (e.g. `docker/web-app`)
+- `build_cmd`: command to build your site (e.g. `pnpm run build`)
+- `start_cmd`: command to launch the production server (e.g. `pnpm run start`)
+- `port`: port that the server listens on (default `3000`)
+- `keep`: number of historical PDFs to preserve (default `5`)
+- `pdf_dir`: path in the repo where PDFs are saved (default `docs/visual-regression`)
+- `commit`: set to `false` to skip committing in CI examples
 
 ### How it works
-1. Install & build: runs your install and build steps in the specified workdir.
+1. Install & build: runs your install and build steps in the specified `workdir`.
 2. Start server: boots the production build and waits for the port to open.
 3. Crawl & render: automatically follows links up to the given depth, captures each page into a PDF buffer, then merges them.
-4. Commit & prune: places the new PDF into pdf_dir with the current commit SHA, deletes any beyond the newest keep, and pushes the change back.
+4. Commit & prune: places the new PDF into `pdf_dir` with the current commit SHA, deletes any beyond the newest `keep`, and pushes the change back.
 
 #### Example usage
 
-_In your .github/workflows/visreg.yml, include:_
+_In your `.github/workflows/visreg.yml`, include:_
 
 ```yaml
 uses: Cdaprod/nextjs-visreg-pdf@v1
@@ -45,10 +46,11 @@ with:
   port: 3000
   keep: 5
   pdf_dir: public/visual-regression
-``` 
+```
 
 That’s it—on each push to main you’ll end up with a shareable PDF of your whole app, and your repo will always contain only the last five visual-regression artifacts.
 
 ⸻
 
 Built and maintained by Cdaprod. Feel free to open issues or pull requests!
+

--- a/action.yml
+++ b/action.yml
@@ -1,25 +1,22 @@
 name: 'Next.js visual-regression → PDF'
 author: 'Cdaprod'
 description: >
-  Autonomous PDF generator--Visual Regression Testing for small projects.
+  Visual regression PDF generator that crawls a Docker-built Next.js app.
 
 inputs:
-  workdir:
-    description: 'Sub-directory that contains the Next.js app'
+  context:
+    description: 'Docker build context for the app'
     default: '.'
-  build_cmd:
-    description: 'Command to build the site'
-    default: 'pnpm run build'
-  start_cmd:
-    description: 'Command that starts the production server'
-    default: 'pnpm run start'
+  dockerfile:
+    description: 'Dockerfile within the context'
+    default: 'Dockerfile'
   port:
-    description: 'Port the server listens on'
+    description: 'Port exposed by the container and crawler'
     default: '3000'
   keep:
     description: 'How many historical PDFs to keep'
     default: '5'
-  pdf_dir:
+  output_dir:
     description: 'Folder (inside repo) to store PDFs'
     default: 'docs/visual-regression'
   depth:
@@ -36,29 +33,19 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-    - name: ✨ Install pnpm
-      uses: pnpm/action-setup@v2
-      with:
-        version: '8'
     - name: 📦 Install action deps
       run: npm install --omit=dev --no-save
       shell: bash
-    - run: |
-        cd ${{ inputs.workdir }}
-        pnpm install --frozen-lockfile
-      shell: bash
-
-    - name: 🔨 Build
-      run: cd ${{ inputs.workdir }} && ${{ inputs.build_cmd }}
-      shell: bash
-
-    - name: 🚀 Start server
+    - name: 🏗️ Build image
       run: |
-        cd ${{ inputs.workdir }}
-        ${{ inputs.start_cmd }} &
+        docker build -t visreg-app -f ${{ inputs.context }}/${{ inputs.dockerfile }} ${{ inputs.context }}
+      shell: bash
+    - name: 🚀 Run container
+      run: |
+        docker rm -f visreg-run 2>/dev/null || true
+        docker run -d --rm -p ${{ inputs.port }}:${{ inputs.port }} --name visreg-run visreg-app
         npx wait-port ${{ inputs.port }}
       shell: bash
-
     - name: 📸 Crawl & render PDF
       run: |
         node ${{ github.action_path }}/scripts/crawl2pdf.mjs \
@@ -66,24 +53,26 @@ runs:
              ${{ inputs.depth }} \
              visreg.pdf
       shell: bash
-
+    - name: 🛑 Stop container
+      if: always()
+      run: docker stop visreg-run
+      shell: bash
     - name: 🗄️ Move & prune
       run: |
         set -e
-        mkdir -p ${{ inputs.pdf_dir }}
-        cp visreg.pdf ${{ inputs.pdf_dir }}/${{ github.sha }}.pdf
-        cd ${{ inputs.pdf_dir }}
+        mkdir -p ${{ inputs.output_dir }}
+        cp visreg.pdf ${{ inputs.output_dir }}/${{ github.sha }}.pdf
+        cd ${{ inputs.output_dir }}
         ls -t *.pdf | tail -n +$((${{ inputs.keep }}+1)) | xargs -r git rm -f --
       shell: bash
-
     - name: 📬 Commit
       if: ${{ inputs.commit == 'true' }}
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        git config user.name  'visreg-bot'
+        git config user.name 'visreg-bot'
         git config user.email 'visreg-bot@users.noreply.github.com'
-        git add ${{ inputs.pdf_dir }}
+        git add ${{ inputs.output_dir }}
         if git diff --cached --quiet; then
           echo 'nothing to commit'
         else

--- a/action.yml
+++ b/action.yml
@@ -25,14 +25,24 @@ inputs:
   depth:
     description: 'Crawler link depth (0 = only /)'
     default: '2'
+  commit:
+    description: 'Commit/push generated PDFs back to the repo'
+    default: 'true'
 
 runs:
   using: 'composite'
   steps:
-    - name: ✨ Install Node & deps
+    - name: 🔧 Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - name: ✨ Install pnpm
       uses: pnpm/action-setup@v2
       with:
         version: '8'
+    - name: 📦 Install action deps
+      run: npm install --omit=dev --no-save
+      shell: bash
     - run: |
         cd ${{ inputs.workdir }}
         pnpm install --frozen-lockfile
@@ -66,7 +76,8 @@ runs:
         ls -t *.pdf | tail -n +$((${{ inputs.keep }}+1)) | xargs -r git rm -f --
       shell: bash
 
-    - name: � commit
+    - name: 📬 Commit
+      if: ${{ inputs.commit == 'true' }}
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
@@ -80,3 +91,4 @@ runs:
           git push "https://${GH_TOKEN}@github.com/${{ github.repository }}.git" HEAD:${{ github.ref_name }}
         fi
       shell: bash
+

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "nextjs-visreg-pdf",
   "version": "1.0.0",
   "type": "module",
+  "scripts": {
+    "test": "node --test scripts/crawl2pdf.test.mjs"
+  },
   "dependencies": {
     "pdf-lib": "^1.17.1",
     "puppeteer": "^22.0.0",

--- a/scripts/crawl2pdf.test.mjs
+++ b/scripts/crawl2pdf.test.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+// Basic tests for crawl2pdf.mjs
+// Usage: node --test scripts/crawl2pdf.test.mjs
+// Example: npm test
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
+
+test('requires base URL', () => {
+  const proc = spawnSync(process.execPath, ['scripts/crawl2pdf.mjs'], { encoding: 'utf8' });
+  assert.notEqual(proc.status, 0);
+  assert.match(proc.stderr, /Usage: node crawl2pdf\.mjs/);
+});


### PR DESCRIPTION
## Summary
- refine visual regression PDF action with optional commit step and runtime dependency install
- document usage and inputs for the action
- add CI workflow with smoke test and example invocation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893dae745608326a42eae2e69866d35